### PR TITLE
Updates to drop diameter Poisson corrections, WINTRE-MIX file handling, and inter arrival time thresholding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# autosave files #
+*.asv

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 # autosave files #
 *.asv
+
+# text output #
+*.txt

--- a/Image_Analysis/Image_Analysis_Calculate_Parameters_Level_2.m
+++ b/Image_Analysis/Image_Analysis_Calculate_Parameters_Level_2.m
@@ -1,4 +1,4 @@
-function [diameter,num_holes,num_pieces,perimeter,area,aspect_ratio,roundness,orientation,circularity,filled_image]=Image_Analysis_Calculate_Parameters_Level_2(image_buffer,in_status)
+function [diameter,num_holes,num_pieces,perimeter,area,filled_area,aspect_ratio,roundness,orientation,circularity,filled_image]=Image_Analysis_Calculate_Parameters_Level_2(image_buffer,in_status)
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % This is the second level of image analysis. The purpose of this level is
 % to correct images that have been distorted dues to Poisson Spots. We will 
@@ -29,7 +29,7 @@ num_holes=num_pieces - eulernum;
 
 %% Calculate circularity, roundness, area ratio, and aspect ratio for images
 %% that are 'all-in'
-[perimeter,area,filled_image]=calculate_perimeter(image_buffer_reversed);
+[perimeter,area,filled_area,filled_image]=calculate_perimeter(image_buffer_reversed);
 
 
 % Find the major axis length (in other words, the maximum diameter) of the
@@ -49,9 +49,11 @@ if in_status ~= 'A'
     orientation = NaN;
     perimeter = NaN;
     area = NaN;
+    area_ratio = NaN;
 else
     aspect_ratio = max_length / min_length;
     circularity = (4*pi*area) / (perimeter^2);
     roundness = (4*area) / (pi*max_length^2);
     orientation = stats.Orientation;
+    area_ratio = filled_area/(pi*(0.5*diameter)^2);
 end

--- a/Image_Analysis/Image_Analysis_Calculate_Parameters_Level_2.m
+++ b/Image_Analysis/Image_Analysis_Calculate_Parameters_Level_2.m
@@ -52,8 +52,8 @@ if in_status ~= 'A'
     area_ratio = NaN;
 else
     aspect_ratio = max_length / min_length;
-    circularity = (4*pi*area) / (perimeter^2);
-    roundness = (4*area) / (pi*max_length^2);
+    circularity = (4*pi*filled_area) / (perimeter^2);
+    roundness = (4*filled_area) / (pi*max_length^2);
     orientation = stats.Orientation;
     area_ratio = filled_area/(pi*(0.5*diameter)^2);
 end

--- a/Image_Analysis/Image_Analysis_Poisson_Correction_Level_3.m
+++ b/Image_Analysis/Image_Analysis_Poisson_Correction_Level_3.m
@@ -1,4 +1,4 @@
-function [poisson_corrected,diameter]=Image_Analysis_Poisson_Correction_Level_3(diameter,aspect_ratio,area_ratio,circularity,roundness,filled_image)
+function [poisson_corrected,diameter]=Image_Analysis_Poisson_Correction_Level_3(diameter,area,filled_area,num_pieces,num_holes,circularity,roundness)
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % This is the third level of image analysis. The purpose of this level is
 % to calculate any parameters that we are interested in.
@@ -6,7 +6,7 @@ function [poisson_corrected,diameter]=Image_Analysis_Poisson_Correction_Level_3(
 
 % If the image is somewhat circular and has only 1 hole, we correct it. The
 % smaller then image, the less circular the image has to be.
-if area_ratio > 0.9
+if circularity > 0.6 && roundness > 0.7
     if num_holes == 1 && num_pieces == 1
         % Find the area of the hole and then the equivalent diameters of the
         % hole and the filled image

--- a/Image_Analysis/Image_Analysis_core.m
+++ b/Image_Analysis/Image_Analysis_core.m
@@ -357,8 +357,8 @@ for i=((n-1)*nEvery+1):min(n*nEvery,handles.img_count)
                 % 3.
 
                 if artifact_status(kk)==1
-                    [diameter(kk),number_of_holes(kk),number_of_pieces(kk),perimeter(kk),area(kk),aspect_ratio(kk),roundness(kk),orientation(kk),circularity(kk),filled_image]=Image_Analysis_Calculate_Parameters_Level_2(c,in_status(kk));
-                    [poisson_corrected(kk),diameter(kk)]=Image_Analysis_Poisson_Correction_Level_3(diameter(kk),aspect_ratio(kk),area_ratio(kk),circularity(kk),roundness(kk),filled_image);
+                    [diameter(kk),number_of_holes(kk),number_of_pieces(kk),perimeter(kk),area(kk),filled_area(kk),aspect_ratio(kk),roundness(kk),orientation(kk),circularity(kk)]=Image_Analysis_Calculate_Parameters_Level_2(c,in_status(kk));
+                    [poisson_corrected(kk),diameter(kk)]=Image_Analysis_Poisson_Correction_Level_3(diameter(kk),area(kk),filled_area(kk),number_of_pieces(kk),number_of_holes(kk),circularity(kk),roundness(kk));
                 end
                 
                 perimeter(kk) = perimeter(kk) * diodesize *1000;

--- a/Image_Analysis/calculate_perimeter.m
+++ b/Image_Analysis/calculate_perimeter.m
@@ -1,4 +1,4 @@
-function [perimeter,area,filled_image]=calculate_perimeter(image_buffer_reversed)
+function [perimeter,area,filled_area,filled_image]=calculate_perimeter(image_buffer_reversed)
 perimeter = 0;
 unshadowed_edges = 0;
 
@@ -21,11 +21,13 @@ end
 
 % Fill all holes in the image before calculating area. Filling the hole
 % here just applies to calculations; it does not change the actual image 
-% when viewed.
+% when viewed. Both areas are preserved
+
+stats=regionprops(image_buffer_reversed,'Area');
+area=stats.Area;
 filled_image = imfill(image_buffer_reversed,8,'holes');
 stats=regionprops(filled_image,'Area');
-area=stats.Area;
-
+filled_area=stats.Area;
 
 for i=1:n_slices
     for j=1:bits

--- a/Size_Distributions/Generate_SizeDist.m
+++ b/Size_Distributions/Generate_SizeDist.m
@@ -28,22 +28,24 @@ end
 disp(['Generating Size Distribution for the ',probename]);
 
 %% Read the setup file with bin edges
-[roundness_bin_edges,num_round_bins,In_status,in_status_value,diam_bin_edges,num_diam_bins,mid_bin_diams,aspect_ratio_bin_edges,num_aspect_ratio_bins]=setup_SizeDist(probename);
+[roundness_bin_edges,num_round_bins,In_status,in_status_value,diam_bin_edges,num_diam_bins,mid_bin_diams,aspect_ratio_bin_edges,num_ar_bins,circularity_bin_edges,num_circ_bins]=setup_SizeDist(probename);
 
 %% Create NaN arrays
-accepted_counts  = zeros(length(timehhmmss),num_diam_bins)*NaN;
-total_accepted_counts = zeros(length(timehhmmss),1)*NaN;
-total_rejected_counts = zeros(length(timehhmmss),num_rejects+1)*NaN;
-roundness_counts = zeros(length(timehhmmss),num_round_bins)*NaN;
-aspect_ratio_counts = zeros(length(timehhmmss),num_aspect_ratio_bins)*NaN;
-sample_volume = zeros(length(timehhmmss),num_diam_bins)*NaN;
-size_dist = zeros(length(timehhmmss),num_diam_bins)*NaN;
+accepted_counts  = NaN(length(timehhmmss),num_diam_bins);
+total_accepted_counts = NaN(length(timehhmmss),1);
+total_rejected_counts = NaN(length(timehhmmss),num_rejects+1);
+roundness_counts = NaN(num_diam_bins,num_round_bins,length(timehhmmss));
+circularity_counts = NaN(num_diam_bins,num_circ_bins,length(timehhmmss));
+aspect_ratio_counts = NaN(num_diam_bins,num_ar_bins,length(timehhmmss));
+sample_volume = NaN(length(timehhmmss),num_diam_bins);
+size_dist = NaN(length(timehhmmss),num_diam_bins);
+
 switch probename
     case '2DS'
-        accepted_counts_H = zeros(length(timehhmmss),num_diam_bins)*NaN;
-        accepted_counts_V = zeros(length(timehhmmss),num_diam_bins)*NaN;
-        size_dist_H = zeros(length(timehhmmss),num_diam_bins)*NaN;
-        size_dist_V = zeros(length(timehhmmss),num_diam_bins)*NaN;
+        accepted_counts_H = NaN(length(timehhmmss),num_diam_bins);
+        accepted_counts_V = NaN(length(timehhmmss),num_diam_bins);
+        size_dist_H = NaN(length(timehhmmss),num_diam_bins);
+        size_dist_V = NaN(length(timehhmmss),num_diam_bins);
 end
 min_bin_diams = diam_bin_edges(1:end-1);
 max_bin_diams = diam_bin_edges(2:end);
@@ -58,13 +60,12 @@ for x = 1:length(PROC_files)
     disp(['Reading in file: ',PROC_files(x).folder,'/',PROC_files(x).name])
     infile = netcdf.open([PROC_files(x).folder,'/',PROC_files(x).name],'nowrite');
     times = netcdf.getVar(infile,netcdf.inqVarID(infile,'Time'));
-    first_PROC_time = times(1);
-    last_PROC_time = times(end);
 
     % Read in other variables
     diameter = netcdf.getVar(infile,netcdf.inqVarID(infile,'diameter'));
     artifacts = netcdf.getVar(infile,netcdf.inqVarID(infile,'artifact_status'));
     roundness = netcdf.getVar(infile,netcdf.inqVarID(infile,'roundness'));
+    circularity = netcdf.getVar(infile,netcdf.inqVarID(infile,'circularity'));
     aspect_ratio = netcdf.getVar(infile,netcdf.inqVarID(infile,'aspect_ratio'));
     inter_arrival = netcdf.getVar(infile,netcdf.inqVarID(infile,'inter_arrival'));
     shattered = inter_arrival <= IA_threshold; %logical indices of all shattered particles
@@ -86,25 +87,21 @@ for x = 1:length(PROC_files)
     num_rejects = netcdf.getAtt(infile, netcdf.inqVarID(infile,'artifact_status'),'Number of artifact statuses')+1;
     
     %% Create the output file
-    [f,varid]=define_outfile_SizeDist(probename,num_rejects,timehhmmss,outfile,num_round_bins,num_diam_bins,In_status,num_aspect_ratio_bins,IA_threshold);
-
-    % Fix flight times if they span multiple days
-    timehhmmss(find(diff(timehhmmss)<0)+1:end) = timehhmmss(find(diff(timehhmmss)<0)+1:end) + 240000;
-    timehhmmss = mod(timehhmmss, 240000);
+    [f,varid]=define_outfile_SizeDist(probename,num_rejects,timehhmmss,outfile,num_round_bins,num_diam_bins,In_status,num_ar_bins,num_circ_bins,IA_threshold);
+    
+    % Times shared by aircraft and probe data
+    times_both = times(ismember(times,timehhmmss));
+    
+    % Increment PROC if no matching times
+    if isempty(times), continue, end
+    
+    first_PROC_time = times_both(1);
+    last_PROC_time = times_both(end);
 
     % Find the first and last time that is available in both the PROC and
     % aircraft files. We will loop over these times to create the SD file.
-    first_time_index = find(timehhmmss >= first_PROC_time);
-    first_time = timehhmmss(first_time_index(1));
-    last_time = min(last_PROC_time,timehhmmss(end));
-
-    first_time = hhmmss2sec(first_time);
-    last_time = hhmmss2sec(last_time);
-    
-    length_of_times = last_time - first_time;
-    end_index = first_time_index(1) + length_of_times - 1;
-    end_index = min(end_index,length(timehhmmss));
-
+    first_time_index = find(timehhmmss == first_PROC_time);
+    end_time_index = find(timehhmmss == last_PROC_time);
 
     %% Calculate sample area depending on whether we are considering center-in or only all-in images 
     
@@ -127,9 +124,8 @@ for x = 1:length(PROC_files)
 
 
     %% Loop over every second
-    for i = first_time_index(1):end_index
-        current_time=(i-first_time_index(1))+first_time; % This is now equivalent to a time in the PROC file and nc file, incrementing by 1 as we go through the for loop
-        current_hhmmss = sec2hhmmss(current_time);
+    for i = first_time_index:end_time_index
+        current_hhmmss = timehhmmss(i);
 
         % Find the indices of all the particles that correspond to this time
         good_indices = find(times == current_hhmmss);
@@ -139,8 +135,9 @@ for x = 1:length(PROC_files)
         accepted_counts(i,:) = 0;
         total_accepted_counts(i) = 0;
         total_rejected_counts(i,:) = 0;
-        roundness_counts(i,:) = 0;
-        aspect_ratio_counts(i,:)=0;
+        roundness_counts(:,:,i) = 0;
+        circularity_counts(:,:,i) = 0;
+        aspect_ratio_counts(:,:,i) = 0;
         switch probename
             case '2DS'
                 accepted_counts_H(i,:) = 0;
@@ -159,6 +156,7 @@ for x = 1:length(PROC_files)
             good_diameters = diameter(good_indices); % Find the diameters of all particles in this time
             good_artifacts = artifacts(good_indices); % Find the artifact statuses
             good_roundness = roundness(good_indices); % Find the area ratios
+            good_circularity = circularity(good_indices); % Find the circularities
             good_aspect_ratio = aspect_ratio(good_indices); %Find the aspect ratios
             switch probename
                 case '2DS'
@@ -175,16 +173,17 @@ for x = 1:length(PROC_files)
                             case 1 % Particle is not rejected
                                 %% Rejection counts
                                 lower_bin_numbers = find(diam_bin_edges <= good_diameters(j));
-                                bin_number = lower_bin_numbers(end); % This is the number of the bin that the diameter fits into
-                                accepted_counts(i,bin_number) = accepted_counts(i,bin_number) + 1;
+                                diam_bin_number = lower_bin_numbers(end); % This is the number of the bin that the diameter fits into
+                                if diam_bin_number == length(diam_bin_edges) continue, end % Advances particle if D doesnt fit into a bin
+                                accepted_counts(i,diam_bin_number) = accepted_counts(i,diam_bin_number) + 1;
                                 total_accepted_counts(i) = total_accepted_counts(i) + 1;
                                 switch probename
                                     case '2DS'
                                         switch good_channel(j)
                                             case 'H'
-                                                accepted_counts_H(i,bin_number) = accepted_counts_H(i,bin_number) + 1;
+                                                accepted_counts_H(i,diam_bin_number) = accepted_counts_H(i,diam_bin_number) + 1;
                                             case 'V'
-                                                accepted_counts_V(i,bin_number) = accepted_counts_V(i,bin_number) + 1;
+                                                accepted_counts_V(i,diam_bin_number) = accepted_counts_V(i,diam_bin_number) + 1;
                                             otherwise
 %                                                 disp('Error')
 %                                                 disp('Shutting down')
@@ -194,17 +193,25 @@ for x = 1:length(PROC_files)
                                 %% Roundness counts
                                 if ~isnan(good_roundness(j))
                                     lower_bin_numbers = find(roundness_bin_edges <= good_roundness(j));
-                                    bin_number = lower_bin_numbers(end); % This is the number of the bin that the roundness fits into
+                                    round_bin_number = lower_bin_numbers(end); % This is the number of the bin that the roundness fits into
                                     % Add counts to roundness bins
-                                    roundness_counts(i,bin_number) = roundness_counts(i,bin_number) + 1;
+                                    roundness_counts(diam_bin_number,round_bin_number,i) = roundness_counts(diam_bin_number,round_bin_number,i) + 1;
                                 end
                                 
+                                if ~isnan(good_circularity(j))
+                                    %% Circularity counts
+                                    lower_bin_numbers = find(circularity_bin_edges <= good_circularity(j));
+                                    circ_bin_number = lower_bin_numbers(end); % This is the number of the bin that the circularity fits into
+                                    % Add counts to roundness bins
+                                    circularity_counts(diam_bin_number,circ_bin_number,i) = circularity_counts(diam_bin_number,circ_bin_number,i) + 1;
+                                end
+
                                 if ~isnan(good_aspect_ratio(j))
                                     %% Aspect ratio counts
                                     lower_bin_numbers = find(aspect_ratio_bin_edges <= good_aspect_ratio(j));
-                                    bin_number = lower_bin_numbers(end); % This is the number of the bin that the area ratio fits into
+                                    ar_bin_number = lower_bin_numbers(end); % This is the number of the bin that the area ratio fits into
                                     % Add counts to roundness bins
-                                    aspect_ratio_counts(i,bin_number) = aspect_ratio_counts(i,bin_number) + 1;
+                                    aspect_ratio_counts(diam_bin_number,ar_bin_number,i) = aspect_ratio_counts(diam_bin_number,ar_bin_number,i) + 1;
                                 end
                                 
                             otherwise
@@ -220,7 +227,7 @@ end
 size_dist = accepted_counts ./ sample_volume;
 switch probename
     case '2DS'
-        size_dist = size_dist ./ 2; %Need to divide concentrations by 2 becuase the 2DS has two channels
+        size_dist = size_dist / 2; %Need to divide concentrations by 2 becuase the 2DS has two channels
         size_dist_H = accepted_counts_H ./ sample_volume;
         size_dist_V = accepted_counts_V ./ sample_volume;
 end
@@ -243,6 +250,7 @@ netcdf.putVar ( f, varid.bin_min, min_bin_diams);
 netcdf.putVar ( f, varid.bin_max, max_bin_diams);
 netcdf.putVar ( f, varid.bin_mid, mid_bin_diams);
 netcdf.putVar ( f, varid.roundness_counts, roundness_counts);
+netcdf.putVar ( f, varid.circularity_counts, circularity_counts);
 netcdf.putVar ( f, varid.aspect_ratio_counts, aspect_ratio_counts);
 netcdf.putVar ( f, varid.total_reject_counts, total_rejected_counts);       
 switch probename
@@ -253,7 +261,7 @@ switch probename
         netcdf.putVar ( f, varid.size_dist_2DS_V, size_dist_V);
 end
 netcdf.putVar ( f, varid.size_dist, size_dist);
-
+netcdf.putVar ( f, varid.sample_volume, sample_volume);
 netcdf.close(f);
 
 end

--- a/Size_Distributions/define_outfile_SizeDist.m
+++ b/Size_Distributions/define_outfile_SizeDist.m
@@ -1,4 +1,4 @@
-function [f,varid]=define_outfile_SizeDist(probename,num_rejects,timehhmmss,outfile,num_round_bins,num_diam_bins,In_status,num_aspect_ratio_bins,IA_threshold)
+function [f,varid]=define_outfile_SizeDist(probename,num_rejects,timehhmmss,outfile,num_round_bins,num_diam_bins,In_status,num_aspect_ratio_bins,num_circ_bins,IA_threshold)
 
 %% Create outfile and define variables
 f = netcdf.create(outfile, 'clobber');
@@ -7,6 +7,7 @@ dimid1 = netcdf.defDim(f,'bin_count',num_diam_bins);
 dimid2 = netcdf.defDim(f,'reject_status',num_rejects);
 dimid3 = netcdf.defDim(f,'roundness_bin_count',num_round_bins);
 dimid4 = netcdf.defDim(f,'aspect_ratio_bin_count',num_aspect_ratio_bins);
+dimid5 = netcdf.defDim(f,'circularity_bin_count',num_circ_bins);
 
 netcdf.putAtt(f, netcdf.getConstant('NC_GLOBAL'),'In_status',In_status);
 netcdf.putAtt(f, netcdf.getConstant('NC_GLOBAL'),'inter_arrival_threshold',IA_threshold);
@@ -29,11 +30,14 @@ netcdf.putAtt(f, varid.bin_max,'units','micrometers');
 varid.bin_mid = netcdf.defVar(f,'bin_mid','double',dimid1);
 netcdf.putAtt(f, varid.bin_mid,'long_name','Midpoint of each bin');
 netcdf.putAtt(f, varid.bin_mid,'units','micrometers');
-varid.roundness_counts = netcdf.defVar(f,'roundness_counts','double',[dimid0 dimid3]);
-netcdf.putAtt(f, varid.roundness_counts,'long_name','Binwise counts of roundness. Only all-in images have roundness values');
+varid.roundness_counts = netcdf.defVar(f,'roundness_counts','double',[dimid1 dimid3 dimid0]);
+netcdf.putAtt(f, varid.roundness_counts,'long_name','Accepted counts of roundness binned by diameter. Only all-in images have roundness values');
 netcdf.putAtt(f, varid.roundness_counts,'units','unitless');
-varid.aspect_ratio_counts = netcdf.defVar(f,'aspect_ratio_counts','double',[dimid0 dimid4]);
-netcdf.putAtt(f, varid.aspect_ratio_counts,'long_name','Binwise counts of aspect ratio. Only all-in images have aspect ratio values');
+varid.circularity_counts = netcdf.defVar(f,'circularity_counts','double',[dimid1 dimid5 dimid0]);
+netcdf.putAtt(f, varid.circularity_counts,'long_name','Accepted counts of circularity binned by diameter. Only all-in images have roundness values');
+netcdf.putAtt(f, varid.circularity_counts,'units','unitless');
+varid.aspect_ratio_counts = netcdf.defVar(f,'aspect_ratio_counts','double',[dimid1 dimid4 dimid0]);
+netcdf.putAtt(f, varid.aspect_ratio_counts,'long_name','Accepted counts of aspect ratio binned by diameter. Only all-in images have aspect ratio values');
 netcdf.putAtt(f, varid.aspect_ratio_counts,'units','unitless');
 varid.total_reject_counts = netcdf.defVar(f,'total_reject_counts','double',[dimid0 dimid2]);
 netcdf.putAtt(f, varid.total_reject_counts,'long_name','Number of rejected images, sorted by artifact status');
@@ -56,6 +60,9 @@ end
 varid.size_dist = netcdf.defVar(f,['size_dist_',probename],'double',[dimid0 dimid1]);
 netcdf.putAtt(f, varid.size_dist,'long_name',['Size distribution calculated using ',In_status,' images']);
 netcdf.putAtt(f, varid.size_dist,'units','# cm-3 um-1');
+varid.sample_volume = netcdf.defVar(f,'sample_volume','double',[dimid0 dimid1]);
+netcdf.putAtt(f, varid.sample_volume,'long_name','Sample volume used for calculating number concentrations');
+netcdf.putAtt(f, varid.sample_volume,'units','cm3');
 netcdf.endDef(f)
 
 end

--- a/Size_Distributions/define_outfile_SizeDist.m
+++ b/Size_Distributions/define_outfile_SizeDist.m
@@ -1,4 +1,4 @@
-function [f,varid]=define_outfile_SizeDist(probename,num_rejects,timehhmmss,outfile,num_round_bins,num_diam_bins,In_status,num_aspect_ratio_bins)
+function [f,varid]=define_outfile_SizeDist(probename,num_rejects,timehhmmss,outfile,num_round_bins,num_diam_bins,In_status,num_aspect_ratio_bins,IA_threshold)
 
 %% Create outfile and define variables
 f = netcdf.create(outfile, 'clobber');
@@ -9,6 +9,7 @@ dimid3 = netcdf.defDim(f,'roundness_bin_count',num_round_bins);
 dimid4 = netcdf.defDim(f,'aspect_ratio_bin_count',num_aspect_ratio_bins);
 
 netcdf.putAtt(f, netcdf.getConstant('NC_GLOBAL'),'In_status',In_status);
+netcdf.putAtt(f, netcdf.getConstant('NC_GLOBAL'),'inter_arrival_threshold',IA_threshold);
 
 varid.time = netcdf.defVar(f,'time','double',dimid0);
 netcdf.putAtt(f, varid.time,'long_name','Time in format HHMMSS');

--- a/Size_Distributions/run_SizeDist.m
+++ b/Size_Distributions/run_SizeDist.m
@@ -10,18 +10,30 @@ function run_SizeDist(ncfile,PROC_directory,probe)
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 main_nc = netcdf.open(ncfile);
 timesec = netcdf.getVar(main_nc, netcdf.inqVarID(main_nc, 'time'), 'double');
-tas = netcdf.getVar(main_nc, netcdf.inqVarID(main_nc, 'tas'),'double');
+try 
+    tas = netcdf.getVar(main_nc, netcdf.inqVarID(main_nc, 'tas'),'double');
+catch 
+    tas = netcdf.getVar(main_nc, netcdf.inqVarID(main_nc, 'TAS'),'double');
+end
 netcdf.close(main_nc);
 days = floor(timesec/86400);
 hours = floor(mod(timesec,86400)/3600);
 minutes = floor(mod(timesec,3600)/60);
 seconds = mod(timesec,60);
-timehhmmss = double(seconds+minutes*100+hours*10000); 
+timehhmmss = mod(seconds+minutes*100+hours*10000,240000); % Rolls to 0 at 24:00:00UTC after start day
 
 % Find the date and project directory from the nc file
-c1_pos = find(ncfile == '1',1,'last');
-date = ncfile(c1_pos-10:c1_pos-3);
+c1_name = split(ncfile,'/');
+c1_name = char(c1_name(end));
+parts = split(c1_name,{'.','_','-'}); %split nc filename string on '.', '_' or '-' delimiters
+nums = regexp(parts,'\d+','match'); %only numerals
+allnums = vertcat(nums{:}); %fix nested cells
+len = cellfun(@length,allnums); %length of nums cell strings
+date = char(allnums(len == max(len))); %date set to continuous set of numerals of max length
 PROC_directory = ([PROC_directory,'/']);
+
+% In-status to append to name
+[~,~,in_status,in_status_value,~,~,~,~,~]=setup_SizeDist(probe);
 
 % Sanity check to make sure we have true airspeed data for every second
 if length(timehhmmss)==length(tas)
@@ -43,16 +55,16 @@ switch probe
             return;
         end
         
-%         % Read in the artifact statuses to see how many there are. This
-%         % needs to be done so that we can set one of the dimension sizes in
-%         % Generate_SizeDist. By reading this in here, artifact statuses can
-%         % be added, without affecting the size distribution code.
-         PROC_file = netcdf.open([PROC_directory,files(1).name],'nowrite');
-         num_rejects = netcdf.getAtt(PROC_file, netcdf.inqVarID(PROC_file,'artifact_status'),'Number of artifact statuses');
+        % Read in the artifact statuses to see how many there are. This
+        % needs to be done so that we can set one of the dimension sizes in
+        % Generate_SizeDist. By reading this in here, artifact statuses can
+        % be added, without affecting the size distribution code.
+        PROC_file = netcdf.open([PROC_directory,files(1).name],'nowrite');
+        num_rejects = netcdf.getAtt(PROC_file, netcdf.inqVarID(PROC_file,'artifact_status'),'Number of artifact statuses');
         IA_threshold = 1e-5;
         inFile = [PROC_directory,files(1).name];
         proc_pos = find(inFile == 'P',1,'last');
-        outFile = [inFile(1:proc_pos-1),'SD.',date,'.2DS.cdf']
+        outFile = [inFile(1:proc_pos-1),'SD.',date,'_',upper(in_status(1)),'.2DS.cdf']
         Generate_SizeDist(files,outFile,tas,floor(timehhmmss),'2DS',num_rejects,IA_threshold);    
     case {'HVPS','hvps'}
         files = dir([PROC_directory,'PROC.*.HVPS.cdf']);
@@ -66,9 +78,9 @@ switch probe
         % needs to be done so that we can set one of the dimension sizes in
         % Generate_SizeDist. By reading this in here, artifact statuses can
         % be added, without affecting the size distribution code.
-         PROC_file = netcdf.open([PROC_directory,files(1).name],'nowrite');
-         num_rejects = netcdf.getAtt(PROC_file, netcdf.inqVarID(PROC_file,'artifact_status'),'Number of artifact statuses');
-        IA_threshold = 1e-3;
+        PROC_file = netcdf.open([PROC_directory,files(1).name],'nowrite');
+        num_rejects = netcdf.getAtt(PROC_file, netcdf.inqVarID(PROC_file,'artifact_status'),'Number of artifact statuses');
+        IA_threshold = 1e-4;
         inFile = [PROC_directory,files(1).name];
         proc_pos = find(inFile == 'P');
         if length(proc_pos) > 1
@@ -76,8 +88,8 @@ switch probe
         else
             proc_pos = proc_pos(end);
         end
-        outFile = [inFile(1:proc_pos-1),'SD.',date,'.HVPS.cdf']
-        Generate_SizeDist(files,number_of_reject_types,outFile,tas,floor(timehhmmss),'HVPS',num_rejects,IA_threshold);
+        outFile = [inFile(1:proc_pos-1),'SD.',date,'_',upper(in_status(1)),'.HVPS.cdf']
+        Generate_SizeDist(files,outFile,tas,floor(timehhmmss),'HVPS',num_rejects,IA_threshold);
         
     case {'CIPG','cip','cipg','CIP'}
 
@@ -92,8 +104,8 @@ switch probe
         % needs to be done so that we can set one of the dimension sizes in
         % Generate_SizeDist. By reading this in here, artifact statuses can
         % be added, without affecting the size distribution code.
-         PROC_file = netcdf.open([PROC_directory,files(1).name],'nowrite');
-         num_rejects = netcdf.getAtt(PROC_file, netcdf.inqVarID(PROC_file,'artifact_status'),'Number of artifact statuses');
+        PROC_file = netcdf.open([PROC_directory,files(1).name],'nowrite');
+        num_rejects = netcdf.getAtt(PROC_file, netcdf.inqVarID(PROC_file,'artifact_status'),'Number of artifact statuses');
         IA_threshold = 1e-5;
         inFile = [PROC_directory,files(1).name];
         proc_pos = find(inFile == 'P');
@@ -102,8 +114,8 @@ switch probe
         else
             proc_pos = proc_pos(end);
         end
-        outFile = [inFile(1:proc_pos-1),'SD.',date,'.CIP.cdf']
-        Generate_SizeDist(files,number_of_reject_types,outFile,tas,floor(timehhmmss),'CIP',num_rejects,IA_threshold);
+        outFile = [inFile(1:proc_pos-1),'SD.',date,'_',upper(in_status(1)),'.CIP.cdf']
+        Generate_SizeDist(files,outFile,tas,floor(timehhmmss),'CIP',num_rejects,IA_threshold);
 
     case {'2DP','2dp'}
 
@@ -118,8 +130,8 @@ switch probe
         % needs to be done so that we can set one of the dimension sizes in
         % Generate_SizeDist. By reading this in here, artifact statuses can
         % be added, without affecting the size distribution code.
-         PROC_file = netcdf.open([PROC_directory,files(1).name],'nowrite');
-         num_rejects = netcdf.getAtt(PROC_file, netcdf.inqVarID(PROC_file,'artifact_status'),'Number of artifact statuses');
+        PROC_file = netcdf.open([PROC_directory,files(1).name],'nowrite');
+        num_rejects = netcdf.getAtt(PROC_file, netcdf.inqVarID(PROC_file,'artifact_status'),'Number of artifact statuses');
         IA_threshold = 1e-3;
         inFile = [PROC_directory,files(1).name];
         proc_pos = find(inFile == 'P');
@@ -128,8 +140,8 @@ switch probe
         else
             proc_pos = proc_pos(end);
         end
-        outFile = [inFile(1:proc_pos-1),'SD.',date,'.2DP.cdf']
-        Generate_SizeDist(files,number_of_reject_types,outFile,tas,floor(timehhmmss),'2DP',num_rejects,IA_threshold);
+        outFile = [inFile(1:proc_pos-1),'SD.',date,'_',upper(in_status(1)),'.2DP.cdf']
+        Generate_SizeDist(files,outFile,tas,floor(timehhmmss),'2DP',num_rejects,IA_threshold);
         
     case {'2DC','2dc'}
         
@@ -144,13 +156,13 @@ switch probe
         % needs to be done so that we can set one of the dimension sizes in
         % Generate_SizeDist. By reading this in here, artifact statuses can
         % be added, without affecting the size distribution code.
-         PROC_file = netcdf.open([PROC_directory,files(1).name],'nowrite');
-         num_rejects = netcdf.getAtt(PROC_file, netcdf.inqVarID(PROC_file,'artifact_status'),'Number of artifact statuses');
+        PROC_file = netcdf.open([PROC_directory,files(1).name],'nowrite');
+        num_rejects = netcdf.getAtt(PROC_file, netcdf.inqVarID(PROC_file,'artifact_status'),'Number of artifact statuses');
         
         inFile = [PROC_directory,files(1).name];
         proc_pos = find(inFile == 'P',1,'last');
-        outFile = [inFile(1:proc_pos-1),'SD.',date,'.2DC.cdf']
-        Generate_SizeDist(files,number_of_reject_types,outFile,tas,floor(timehhmmss),'2DC',num_rejects);
+        outFile = [inFile(1:proc_pos-1),'SD.',date,'_',upper(in_status(1)),'.2DC.cdf']
+        Generate_SizeDist(files,outFile,tas,floor(timehhmmss),'2DC',num_rejects);
         
 end
 

--- a/Size_Distributions/run_SizeDist.m
+++ b/Size_Distributions/run_SizeDist.m
@@ -49,11 +49,11 @@ switch probe
 %         % be added, without affecting the size distribution code.
          PROC_file = netcdf.open([PROC_directory,files(1).name],'nowrite');
          num_rejects = netcdf.getAtt(PROC_file, netcdf.inqVarID(PROC_file,'artifact_status'),'Number of artifact statuses');
-        
+        IA_threshold = 1e-5;
         inFile = [PROC_directory,files(1).name];
         proc_pos = find(inFile == 'P',1,'last');
         outFile = [inFile(1:proc_pos-1),'SD.',date,'.2DS.cdf']
-        Generate_SizeDist(files,outFile,tas,floor(timehhmmss),'2DS',num_rejects);    
+        Generate_SizeDist(files,outFile,tas,floor(timehhmmss),'2DS',num_rejects,IA_threshold);    
     case {'HVPS','hvps'}
         files = dir([PROC_directory,'PROC.*.HVPS.cdf']);
         filenums = length(files);
@@ -68,7 +68,7 @@ switch probe
         % be added, without affecting the size distribution code.
          PROC_file = netcdf.open([PROC_directory,files(1).name],'nowrite');
          num_rejects = netcdf.getAtt(PROC_file, netcdf.inqVarID(PROC_file,'artifact_status'),'Number of artifact statuses');
-        
+        IA_threshold = 1e-3;
         inFile = [PROC_directory,files(1).name];
         proc_pos = find(inFile == 'P');
         if length(proc_pos) > 1
@@ -77,7 +77,7 @@ switch probe
             proc_pos = proc_pos(end);
         end
         outFile = [inFile(1:proc_pos-1),'SD.',date,'.HVPS.cdf']
-        Generate_SizeDist(files,number_of_reject_types,outFile,tas,floor(timehhmmss),'HVPS',num_rejects);
+        Generate_SizeDist(files,number_of_reject_types,outFile,tas,floor(timehhmmss),'HVPS',num_rejects,IA_threshold);
         
     case {'CIPG','cip','cipg','CIP'}
 
@@ -94,7 +94,7 @@ switch probe
         % be added, without affecting the size distribution code.
          PROC_file = netcdf.open([PROC_directory,files(1).name],'nowrite');
          num_rejects = netcdf.getAtt(PROC_file, netcdf.inqVarID(PROC_file,'artifact_status'),'Number of artifact statuses');
-        
+        IA_threshold = 1e-5;
         inFile = [PROC_directory,files(1).name];
         proc_pos = find(inFile == 'P');
         if length(proc_pos) > 1
@@ -103,7 +103,7 @@ switch probe
             proc_pos = proc_pos(end);
         end
         outFile = [inFile(1:proc_pos-1),'SD.',date,'.CIP.cdf']
-        Generate_SizeDist(files,number_of_reject_types,outFile,tas,floor(timehhmmss),'CIP',num_rejects);
+        Generate_SizeDist(files,number_of_reject_types,outFile,tas,floor(timehhmmss),'CIP',num_rejects,IA_threshold);
 
     case {'2DP','2dp'}
 
@@ -120,7 +120,7 @@ switch probe
         % be added, without affecting the size distribution code.
          PROC_file = netcdf.open([PROC_directory,files(1).name],'nowrite');
          num_rejects = netcdf.getAtt(PROC_file, netcdf.inqVarID(PROC_file,'artifact_status'),'Number of artifact statuses');
-        
+        IA_threshold = 1e-3;
         inFile = [PROC_directory,files(1).name];
         proc_pos = find(inFile == 'P');
         if length(proc_pos) > 1
@@ -129,7 +129,7 @@ switch probe
             proc_pos = proc_pos(end);
         end
         outFile = [inFile(1:proc_pos-1),'SD.',date,'.2DP.cdf']
-        Generate_SizeDist(files,number_of_reject_types,outFile,tas,floor(timehhmmss),'2DP',num_rejects);
+        Generate_SizeDist(files,number_of_reject_types,outFile,tas,floor(timehhmmss),'2DP',num_rejects,IA_threshold);
         
     case {'2DC','2dc'}
         

--- a/Size_Distributions/setup_SizeDist.m
+++ b/Size_Distributions/setup_SizeDist.m
@@ -1,10 +1,11 @@
-function [roundness_bin_edges,num_round_bins,In_status,in_status_value,diam_bin_edges,num_diam_bins,mid_bin_diams,aspect_ratio_bin_edges,num_aspect_ratio_bins]=setup_SizeDist(probename)
+function [roundness_bin_edges,num_round_bins,In_status,in_status_value,diam_bin_edges,num_diam_bins,mid_bin_diams,aspect_ratio_bin_edges,num_aspect_ratio_bins,circularity_bin_edges,num_circ_bins]=setup_SizeDist(probename)
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % This function sets all the bin edges for generating size distributions.
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% All probetypes:
 roundness_bin_edges = [0 0.1 0.2 0.3 0.4 0.5 0.6 0.7 0.8 0.9 1];
-aspect_ratio_bin_edges = [1 1.2 1.4 1.6 1.8 2 2.25 2.5 2.75 3 4 5 7.5 10 100];
+aspect_ratio_bin_edges = [1 1.2 1.4 1.6 1.8 2 2.25 2.5 2.75 3 4 5 7.5 10 100 Inf];
+circularity_bin_edges = [0 0.1 0.2 0.3 0.4 0.5 0.6 0.7 0.8 0.9 1 Inf];
 
 %The following should have a value of ‘center-in’ or ‘all-in’
 In_status = 'all-in';
@@ -12,25 +13,25 @@ In_status = 'all-in';
 %% Probetype-specific:
 switch probename
     case '2DC'
-        diam_bin_edges = [30 50 100 150 200 250 300 350 400 500 600 700 800 900 1000 1150 1300 1500 1750 2000 2500 3000 4000 5000 7500 9600 15000];
-
+        res = 25; %um pixel resolution
+        n = 64;
     case '2DP'
-        diam_bin_edges = [200 400 600 800 1000 1250 1500 1750 2000 2500 3000 3750 4500 5500 6750 8250 10000 15000 20000 30000 45000 64000 100000];
- 
+        res = 200; %um pixel resolution
+        n = 32;
     case 'HVPS'
-        diam_bin_edges = [150 250 400 600 800 1000 1250 1500 1750 2000 2500 3000 3750 4500 5500 6750 8250 10000 15000 20000 30000 50000 100000 192000 500000];
-
+        res = 150; %um pixel resolution
+        n = 128;
     case '2DS'
-        diam_bin_edges = [10 25 50 100 150 200 400 600 800 1000 1250 1500 1750 2000 2500 3000 3750 4500 5500 6750 8250 10000 15000 20000];
-        
+        res = 10; %um pixel resolution
+        n = 128;
     case 'CIP'
-        diam_bin_edges = [25 50 100 150 200 250 300 350 400 500 600 700 800 900 1000 1150 1300 1500 1750 2000 2500 3000 4000 5000 7500 16000];
-        
+        res = 25; %um pixel resolution
+        n = 64;
     otherwise 
         disp('ERROR: Probetype is not supported. Please enter one of the following: 2DP, 2DC, 2DS, HVPS, or CIP. Note: Matlab is case sensitive')
         return;
 end
-
+diam_bin_edges = linspace(res,(2*n)*res,2*n); % generates bins of up to 2 times the width of the photodiode array (for center out)
 
 switch In_status
     case {'Center-in','center-in','Centerin','centerin','Center','center'}
@@ -45,6 +46,7 @@ end
 num_round_bins = length(roundness_bin_edges) -1;
 num_aspect_ratio_bins = length(aspect_ratio_bin_edges) -1;
 num_diam_bins = length(diam_bin_edges) -1;
+num_circ_bins = length(circularity_bin_edges)-1;
 
 for i=1:num_diam_bins
     mid_bin_diams(i) = mean(diam_bin_edges(i:i+1))/1000; %Get mid_bin_diams in millimeters for sample area calculation


### PR DESCRIPTION
Drop diameters with Poisson spots corrected per Shaffer ([2022](https://www.proquest.com/docview/2762471002) ) that were missing a few lines of code and falling through conditionals without calling the step 3 function to adjust diameter by lookup table.

Eden Koval's changes ported for WINTRE-MIX use case to add another dimension to the count distributions along shape parameter (circularity, aspect ratio) bin dimensions. Her changes also improved the second-by-second time-matching between aircraft and size distribution data files.

Inter arrival thresholding moved to the size distribution step so that it can be set/reprocessed quickly for different time thresholds to reject ice.

